### PR TITLE
Gemma special case handled

### DIFF
--- a/experiments/run_llm_evals.sh
+++ b/experiments/run_llm_evals.sh
@@ -64,7 +64,7 @@ declare -A languages=(
 )
 
 for lang_code in "${!languages[@]}"; do
-  python3 scripts/run_generative.py \
+  python3 -m scripts.run_generative \
     --model "$MODEL" \
     --dataset "$DATASET" \
     --lang_code "$lang_code" \

--- a/experiments/run_rm_evals.sh
+++ b/experiments/run_rm_evals.sh
@@ -82,7 +82,7 @@ declare -A languages=(
 
 # Loop through each language and run the command
 for lang_code in "${!languages[@]}"; do
-  python3 scripts/run_rewardbench.py \
+  python3 -m scripts.run_rewardbench \
     --model "$MODEL" \
     --chat_template "$CHAT_TEMPLATE" \
     --dataset "$DATASET" \

--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -144,6 +144,10 @@ def main():
         model_modifier = "llama-3.1"
     elif "gemma" in args.model:
         model_modifier = "gemma"
+    elif "glm-4" in  args.model:
+        model_modifier = "glm-4"
+    elif "Qwen2" in  args.model:
+        model_modifier = "qwen-2"
     else:
         model_modifier = None
 

--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -142,6 +142,8 @@ def main():
         model_modifier = "gemini"
     elif "Llama-3.1" in args.model:
         model_modifier = "llama-3.1"
+    elif "gemma" in args.model:
+        model_modifier = "gemma"
     else:
         model_modifier = None
 
@@ -277,6 +279,12 @@ def main():
                 optional_chat_template.append_message(optional_chat_template.roles[0], user_prompt)
                 optional_chat_template.append_message(optional_chat_template.roles[1], None)
                 prompt = optional_chat_template.get_prompt()
+            elif model_modifier == "gemma":
+                # Gemma models don't support `system prompt`.
+                messages = [
+                    {"role": "user", "content": system_prompt + "\n\n" + user_prompt},
+                ]
+                prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
             elif model_modifier:
                 messages = [
                     {"role": "system", "content": system_prompt},


### PR DESCRIPTION
Gemma does not support system prompts and FastChat template does not work in the current setup. Fixed by concatenating system and user prompts using double-newline and applying tokenizer's chat template.